### PR TITLE
Adding the platformId property

### DIFF
--- a/bolides/bolide.py
+++ b/bolides/bolide.py
@@ -34,6 +34,11 @@ class Bolide():
                 for idx in range(len(self.json['attachments']))]
 
     @property
+    def platformId(self):
+        return [self.json['attachments'][idx]['platformId']
+               for idx in range(len(self.json['attachments']))]
+
+    @property
     def longitudes(self):
         return [
                     [x['location']['coordinates'][0]


### PR DESCRIPTION
Adding platformId as a handy container to track which satellite the signal comes from.  Particularly useful for events that were detected by both satellites or those where the signal was spread over multiple netcdf files.